### PR TITLE
🔒 Fix potential exposure of private stats in README badge

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -19,7 +19,7 @@
 - Email: dblayzer [at] gmail [dot] com
 
 ## GitHub Stats
-![GitHub Stats](https://github-readme-stats.vercel.app/api?username=Dor-bl&show_icons=true&count_private=true)
+![GitHub Stats](https://github-readme-stats.vercel.app/api?username=Dor-bl&show_icons=true)
 
 ## 🚀 Support My Work  
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/Dor-bl?style=for-the-badge&color=purple)](https://github.com/sponsors/Dor-bl)


### PR DESCRIPTION
🎯 **What:** Removed the `count_private=true` parameter from the GitHub Stats image URL in `README.MD`.
⚠️ **Risk:** If the Vercel deployment of `github-readme-stats` is authenticated, the `count_private=true` parameter would expose private repository statistics on the public profile.
🛡️ **Solution:** Removed the `&count_private=true` flag from the URL, ensuring only public statistics are displayed on the profile badge.

---
*PR created automatically by Jules for task [5846544194031797218](https://jules.google.com/task/5846544194031797218) started by @Dor-bl*